### PR TITLE
docker-compose.yml 中の不要 build: 行を削除

### DIFF
--- a/articles/docker-compose.yml
+++ b/articles/docker-compose.yml
@@ -4,5 +4,4 @@ services:
     image: vvakame/review:3.2
     volumes:
       - .:/startDNS
-    build: .
     working_dir: /startDNS


### PR DESCRIPTION
Dockerfileの置いていないフォルダを build: に指定するのは docker-compose.yml としては正しくありません。
今回はイメージをbuildする必要はないように見えますので、シンプルに build: を消す変更です。

build不要と判断した理由は以下の通りです:
このリポジトリにおいてbuildが必要になりそうなのは最終生成物には欲しいが原稿ファイル中に書きたくない(リポジトリに入れたくない)情報がある場合ぐらいと最初は想定した。
が、その場合でも以下のような手段でイメージをbuildせずに対応ができそうであるため。
- docker-compose.yml内にenvironmentを書いて環境変数(.env等)で渡し、 `#@mapoutput()` 〜 `#@end` で展開する。
- config.yml の words_file: を使って展開させる。

ひとまず。